### PR TITLE
Tmp/dm/rcs tests update new inputs outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "beachball": "^2.47.1"
+    "beachball": "^2.51.0"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     devDependencies:
       beachball:
-        specifier: ^2.47.1
-        version: 2.48.0(typescript@5.1.6)
+        specifier: ^2.51.0
+        version: 2.51.0
 
   typescript/examples/code-samples:
     dependencies:
       '@itwin/node-cli-authorization':
         specifier: ^1.0.0
-        version: 1.0.1(@itwin/core-bentley@4.10.5)(@itwin/core-geometry@4.10.5)
+        version: 1.0.1(@itwin/core-bentley@4.10.7)(@itwin/core-geometry@4.10.7)
       '@itwin/reality-capture-analysis':
         specifier: workspace:*
         version: link:../../packages/reality-capture-analysis
@@ -74,7 +74,7 @@ importers:
         version: 4.8.3(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-react@4.17.3)(@types/react@18.0.0)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/appui-react':
         specifier: ^4.0.0
-        version: 4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/components-react@4.17.3)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-frontend@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-quantity@4.9.6)(@itwin/core-react@4.17.3)(@itwin/core-telemetry@4.10.5)(@itwin/imodel-components-react@4.17.3)(@types/react@18.0.0)(react-dom@18.3.1)(react-redux@8.1.3)(react@18.3.1)(redux@4.2.1)
+        version: 4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/components-react@4.17.3)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-frontend@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-quantity@4.9.6)(@itwin/core-react@4.17.3)(@itwin/core-telemetry@4.10.7)(@itwin/imodel-components-react@4.17.3)(@types/react@18.0.0)(react-dom@18.3.1)(react-redux@8.1.3)(react@18.3.1)(redux@4.2.1)
       '@itwin/browser-authorization':
         specifier: ^0.5.1
         version: 0.5.1(@itwin/core-bentley@4.9.6)
@@ -89,7 +89,7 @@ importers:
         version: 4.9.6(@itwin/core-bentley@4.9.6)(@itwin/core-geometry@4.9.6)
       '@itwin/core-frontend':
         specifier: ^4.0.0
-        version: 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.1)(reflect-metadata@0.1.14)
+        version: 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.2)(reflect-metadata@0.1.14)
       '@itwin/core-geometry':
         specifier: ^4.0.0
         version: 4.9.6
@@ -229,7 +229,7 @@ importers:
         version: link:../reality-data-transfer
       '@itwin/service-authorization':
         specifier: ^1.0.0
-        version: 1.2.2(@itwin/core-bentley@4.10.5)(@itwin/core-geometry@4.10.5)
+        version: 1.2.2(@itwin/core-bentley@4.10.7)(@itwin/core-geometry@4.10.7)
       '@types/chai':
         specifier: ^4.3.3
         version: 4.3.20
@@ -302,7 +302,7 @@ importers:
         version: link:../reality-data-transfer
       '@itwin/service-authorization':
         specifier: ^1.0.0
-        version: 1.2.2(@itwin/core-bentley@4.10.5)(@itwin/core-geometry@4.10.5)
+        version: 1.2.2(@itwin/core-bentley@4.10.7)(@itwin/core-geometry@4.10.7)
       '@types/chai':
         specifier: ^4.3.3
         version: 4.3.20
@@ -360,7 +360,7 @@ importers:
         version: link:../reality-data-transfer
       '@itwin/service-authorization':
         specifier: ^1.0.0
-        version: 1.2.2(@itwin/core-bentley@4.10.5)(@itwin/core-geometry@4.10.5)
+        version: 1.2.2(@itwin/core-bentley@4.10.7)(@itwin/core-geometry@4.10.7)
       '@types/chai':
         specifier: ^4.3.3
         version: 4.3.20
@@ -509,7 +509,7 @@ importers:
         version: 2020.9.8
       axios-mock-adapter:
         specifier: ^1.21.3
-        version: 1.22.0(axios@1.7.9)
+        version: 1.22.0(axios@1.8.1)
       chai:
         specifier: ^4.3.6
         version: 4.5.0
@@ -783,6 +783,13 @@ packages:
 
   /@babel/runtime@7.26.0:
     resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.1
+    dev: false
+
+  /@babel/runtime@7.26.9:
+    resolution: {integrity: sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
@@ -1163,7 +1170,7 @@ packages:
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
-      import-fresh: 3.3.0
+      import-fresh: 3.3.1
       js-yaml: 4.1.0
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
@@ -1322,7 +1329,7 @@ packages:
       - '@types/react'
     dev: false
 
-  /@itwin/appui-react@4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/components-react@4.17.3)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-frontend@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-quantity@4.9.6)(@itwin/core-react@4.17.3)(@itwin/core-telemetry@4.10.5)(@itwin/imodel-components-react@4.17.3)(@types/react@18.0.0)(react-dom@18.3.1)(react-redux@8.1.3)(react@18.3.1)(redux@4.2.1):
+  /@itwin/appui-react@4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/components-react@4.17.3)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-frontend@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-quantity@4.9.6)(@itwin/core-react@4.17.3)(@itwin/core-telemetry@4.10.7)(@itwin/imodel-components-react@4.17.3)(@types/react@18.0.0)(react-dom@18.3.1)(react-redux@8.1.3)(react@18.3.1)(redux@4.2.1):
     resolution: {integrity: sha512-UD7qIdQXySZj5gRSiY+tGno4jo3Hf8szK2JHKW0Llcl2SN/FcHurfYIjYaK5rtpsRzra9Qsa01WCIbajujwGVw==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.7.0 || ^4.0.0
@@ -1345,11 +1352,11 @@ packages:
       '@itwin/components-react': 4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-react@4.17.3)(@types/react@18.0.0)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/core-bentley': 4.9.6
       '@itwin/core-common': 4.9.6(@itwin/core-bentley@4.9.6)(@itwin/core-geometry@4.9.6)
-      '@itwin/core-frontend': 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.1)(reflect-metadata@0.1.14)
+      '@itwin/core-frontend': 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.2)(reflect-metadata@0.1.14)
       '@itwin/core-geometry': 4.9.6
       '@itwin/core-quantity': 4.9.6(@itwin/core-bentley@4.9.6)
       '@itwin/core-react': 4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@types/react@18.0.0)(react-dom@18.3.1)(react@18.3.1)
-      '@itwin/core-telemetry': 4.10.5(@itwin/core-geometry@4.9.6)
+      '@itwin/core-telemetry': 4.10.7(@itwin/core-geometry@4.9.6)
       '@itwin/imodel-components-react': 4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/components-react@4.17.3)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-frontend@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-quantity@4.9.6)(@itwin/core-react@4.17.3)(@types/react@18.0.0)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/itwinui-icons-react': 2.9.0(react-dom@18.3.1)(react@18.3.1)
       '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.3.1)(react@18.3.1)
@@ -1429,13 +1436,13 @@ packages:
       - supports-color
     dev: true
 
-  /@itwin/cloud-agnostic-core@2.2.5(inversify@6.2.1)(reflect-metadata@0.1.14):
+  /@itwin/cloud-agnostic-core@2.2.5(inversify@6.2.2)(reflect-metadata@0.1.14):
     resolution: {integrity: sha512-pLEWIjQ4Z1kos7z6RWu/kG2lTEyojr906WVGAXKouxA/BobWuUlb1HG1/Zw8+SovA284wauKhHJsydRhYeddIQ==}
     peerDependencies:
       inversify: ^6.0.1
       reflect-metadata: ^0.1.13
     dependencies:
-      inversify: 6.2.1(reflect-metadata@0.1.14)
+      inversify: 6.2.2(reflect-metadata@0.1.14)
       reflect-metadata: 0.1.14
     dev: false
 
@@ -1468,32 +1475,32 @@ packages:
       - '@types/react'
     dev: false
 
-  /@itwin/core-bentley@4.10.5:
-    resolution: {integrity: sha512-ztTPtYYWty5JaaR3q4t24FHdp2GA9VVZWcYkDkQ8pAI+FiMuCBS9KICnUvarqtuKk1BpoOaFaSCTJ1Dqgjf9Hw==}
+  /@itwin/core-bentley@4.10.7:
+    resolution: {integrity: sha512-h3YFVjaDYCfnk+dVBmU20Mqr8gm/0DuXv1CnZYkbPfFdWCezGvvaYbXdN/FeCaBL1gVtzRWZnnqVWOEKbS9HEA==}
 
   /@itwin/core-bentley@4.9.6:
     resolution: {integrity: sha512-nLXG+Mr/19UkdcayyebVGOvQGQ+uheGz/I12Euu6k/KJroni0FHpJ0Ke0Gy/sOFs+tDCsxcjMQsm0bDT3Hq+OQ==}
 
-  /@itwin/core-common@4.10.5(@itwin/core-bentley@4.10.5)(@itwin/core-geometry@4.9.6):
-    resolution: {integrity: sha512-eR0xp16V9Jmm+M6RAGAeUdzI3kfFfgDxL5jfdvL8n0IwoPszzuIsCPR3VkRE1vzNniwc213nSpjrdi8AHOmcAg==}
+  /@itwin/core-common@4.10.7(@itwin/core-bentley@4.10.7)(@itwin/core-geometry@4.9.6):
+    resolution: {integrity: sha512-/xADVlGhcVA1lHpvV/q+zz+YO5obtNqHpJUxgilFbSA4zQcZ6icUTJGqDzB/oan4r96VBJu2Bwy3FlPrkxUSuQ==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.10.5
-      '@itwin/core-geometry': ^4.10.5
+      '@itwin/core-bentley': ^4.10.7
+      '@itwin/core-geometry': ^4.10.7
     dependencies:
-      '@itwin/core-bentley': 4.10.5
+      '@itwin/core-bentley': 4.10.7
       '@itwin/core-geometry': 4.9.6
       flatbuffers: 1.12.0
       js-base64: 3.7.7
     dev: false
 
-  /@itwin/core-common@4.9.6(@itwin/core-bentley@4.10.5)(@itwin/core-geometry@4.10.5):
+  /@itwin/core-common@4.9.6(@itwin/core-bentley@4.10.7)(@itwin/core-geometry@4.10.7):
     resolution: {integrity: sha512-LyUJnqNxL30DjZ1iR/Tu3QNwHBgV1AvIRq7wVkACjzkPCIWrcCNZKY1zAQR3lXLOTIohU7lwHH3XqPA/qOxoOA==}
     peerDependencies:
       '@itwin/core-bentley': ^4.9.6
       '@itwin/core-geometry': ^4.9.6
     dependencies:
-      '@itwin/core-bentley': 4.10.5
-      '@itwin/core-geometry': 4.10.5
+      '@itwin/core-bentley': 4.10.7
+      '@itwin/core-geometry': 4.10.7
       flatbuffers: 1.12.0
       js-base64: 3.7.7
 
@@ -1508,7 +1515,7 @@ packages:
       flatbuffers: 1.12.0
       js-base64: 3.7.7
 
-  /@itwin/core-frontend@4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.1)(reflect-metadata@0.1.14):
+  /@itwin/core-frontend@4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.2)(reflect-metadata@0.1.14):
     resolution: {integrity: sha512-Uj7kDeuH+a18H9RJaNwJ6eJ4G3ZMSi+wtQX9qIJKtxJaA3TMkt0AdF/50/atbbGtsNCapc7rRoMhf36znNk/OA==}
     peerDependencies:
       '@itwin/appui-abstract': ^4.9.6
@@ -1519,7 +1526,7 @@ packages:
       '@itwin/core-quantity': ^4.9.6
     dependencies:
       '@itwin/appui-abstract': 4.9.6(@itwin/core-bentley@4.9.6)
-      '@itwin/cloud-agnostic-core': 2.2.5(inversify@6.2.1)(reflect-metadata@0.1.14)
+      '@itwin/cloud-agnostic-core': 2.2.5(inversify@6.2.2)(reflect-metadata@0.1.14)
       '@itwin/core-bentley': 4.9.6
       '@itwin/core-common': 4.9.6(@itwin/core-bentley@4.9.6)(@itwin/core-geometry@4.9.6)
       '@itwin/core-geometry': 4.9.6
@@ -1527,7 +1534,7 @@ packages:
       '@itwin/core-orbitgt': 4.9.6
       '@itwin/core-quantity': 4.9.6(@itwin/core-bentley@4.9.6)
       '@itwin/core-telemetry': 4.9.6(@itwin/core-geometry@4.9.6)
-      '@itwin/object-storage-core': 2.2.5(inversify@6.2.1)(reflect-metadata@0.1.14)
+      '@itwin/object-storage-core': 2.2.5(inversify@6.2.2)(reflect-metadata@0.1.14)
       '@itwin/webgl-compatibility': 4.9.6
       '@loaders.gl/core': 3.4.15
       '@loaders.gl/draco': 3.4.15
@@ -1541,10 +1548,10 @@ packages:
       - reflect-metadata
     dev: false
 
-  /@itwin/core-geometry@4.10.5:
-    resolution: {integrity: sha512-TCG+sSh/AYh4g7f/rLH5usIAsKVerGQlH+fdk5zn9rTBmZOgPNSKLnYYnVmZrlz5K2M20Mej8xhbUZwKPzbEBQ==}
+  /@itwin/core-geometry@4.10.7:
+    resolution: {integrity: sha512-bBXuISyeumieSEcApBKUIsXtzPSxdMERh0HTShUorIUG3alv3pPWdKsVtWUizopwSeWxmdxD7vxpdwgAwzbhqQ==}
     dependencies:
-      '@itwin/core-bentley': 4.10.5
+      '@itwin/core-bentley': 4.10.7
       flatbuffers: 1.12.0
 
   /@itwin/core-geometry@4.9.6:
@@ -1576,7 +1583,7 @@ packages:
     dependencies:
       '@itwin/core-bentley': 4.9.6
       '@itwin/core-common': 4.9.6(@itwin/core-bentley@4.9.6)(@itwin/core-geometry@4.9.6)
-      '@itwin/core-frontend': 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.1)(reflect-metadata@0.1.14)
+      '@itwin/core-frontend': 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.2)(reflect-metadata@0.1.14)
       '@itwin/core-geometry': 4.9.6
       '@svgdotjs/svg.js': 3.0.13
     dev: false
@@ -1619,11 +1626,11 @@ packages:
       - '@types/react'
     dev: false
 
-  /@itwin/core-telemetry@4.10.5(@itwin/core-geometry@4.9.6):
-    resolution: {integrity: sha512-8hpgUDjebTBOXdtpncBhpnWrFSEb294Ep0ENsEGE41/0wbQzgtAUoHuwnMuOdqlZ07vyo5Dc8WIEa0h/AMwe6Q==}
+  /@itwin/core-telemetry@4.10.7(@itwin/core-geometry@4.9.6):
+    resolution: {integrity: sha512-pl7Hmx6SgbjTxMz2P7XYW/dlz+b03JxTyKgVsbSM8+eGl3246/zQTBIh0a2eJelFl2FxjkbFNeMvxNAK1RyeDw==}
     dependencies:
-      '@itwin/core-bentley': 4.10.5
-      '@itwin/core-common': 4.10.5(@itwin/core-bentley@4.10.5)(@itwin/core-geometry@4.9.6)
+      '@itwin/core-bentley': 4.10.7
+      '@itwin/core-common': 4.10.7(@itwin/core-bentley@4.10.7)(@itwin/core-geometry@4.9.6)
     transitivePeerDependencies:
       - '@itwin/core-geometry'
     dev: false
@@ -1693,7 +1700,7 @@ packages:
       '@itwin/components-react': 4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-react@4.17.3)(@types/react@18.0.0)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/core-bentley': 4.9.6
       '@itwin/core-common': 4.9.6(@itwin/core-bentley@4.9.6)(@itwin/core-geometry@4.9.6)
-      '@itwin/core-frontend': 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.1)(reflect-metadata@0.1.14)
+      '@itwin/core-frontend': 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.2)(reflect-metadata@0.1.14)
       '@itwin/core-geometry': 4.9.6
       '@itwin/core-quantity': 4.9.6(@itwin/core-bentley@4.9.6)
       '@itwin/core-react': 4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@types/react@18.0.0)(react-dom@18.3.1)(react@18.3.1)
@@ -1730,7 +1737,7 @@ packages:
     dependencies:
       '@itwin/core-bentley': 4.9.6
       '@itwin/core-common': 4.9.6(@itwin/core-bentley@4.9.6)(@itwin/core-geometry@4.9.6)
-      '@itwin/core-frontend': 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.1)(reflect-metadata@0.1.14)
+      '@itwin/core-frontend': 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.2)(reflect-metadata@0.1.14)
       '@itwin/imodels-access-common': 4.1.6(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)
       '@itwin/imodels-client-management': 4.4.0
     transitivePeerDependencies:
@@ -1819,13 +1826,13 @@ packages:
     resolution: {integrity: sha512-bnMlOaX+0Bh+bFdXD1KWBcsgeQTJDvaOY7HXI3ZIADRFy4qnx70DmRMp7w+ZA1FxrX2XTQNjt+kmcphaXTPGCw==}
     dev: false
 
-  /@itwin/node-cli-authorization@1.0.1(@itwin/core-bentley@4.10.5)(@itwin/core-geometry@4.10.5):
+  /@itwin/node-cli-authorization@1.0.1(@itwin/core-bentley@4.10.7)(@itwin/core-geometry@4.10.7):
     resolution: {integrity: sha512-WT1xqucAJKvBT0VvVjHWZWcQno/aWct6YrftB8h4RcuVW7rkH13VCye+BYOrc6Y+/iDVGcvfeBRbv9L24S7mOA==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0 || ^4.0.0
     dependencies:
-      '@itwin/core-bentley': 4.10.5
-      '@itwin/core-common': 4.9.6(@itwin/core-bentley@4.10.5)(@itwin/core-geometry@4.10.5)
+      '@itwin/core-bentley': 4.10.7
+      '@itwin/core-common': 4.9.6(@itwin/core-bentley@4.10.7)(@itwin/core-geometry@4.10.7)
       '@openid/appauth': 1.3.2
       keytar: 7.9.0
       open: 8.4.2
@@ -1835,15 +1842,15 @@ packages:
       - debug
     dev: false
 
-  /@itwin/object-storage-core@2.2.5(inversify@6.2.1)(reflect-metadata@0.1.14):
+  /@itwin/object-storage-core@2.2.5(inversify@6.2.2)(reflect-metadata@0.1.14):
     resolution: {integrity: sha512-IaGryht2Sg2piCVyrnzfTnxSClhi2k8Xv+OxFD2ARvd+J2o3XFgo5EJBezNe1gVz60+9tuqlczIU6blxfbX05g==}
     peerDependencies:
       inversify: ^6.0.1
       reflect-metadata: ^0.1.13
     dependencies:
-      '@itwin/cloud-agnostic-core': 2.2.5(inversify@6.2.1)(reflect-metadata@0.1.14)
+      '@itwin/cloud-agnostic-core': 2.2.5(inversify@6.2.2)(reflect-metadata@0.1.14)
       axios: 1.7.7
-      inversify: 6.2.1(reflect-metadata@0.1.14)
+      inversify: 6.2.2(reflect-metadata@0.1.14)
       reflect-metadata: 0.1.14
     transitivePeerDependencies:
       - debug
@@ -1903,7 +1910,7 @@ packages:
       '@itwin/components-react': 4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-react@4.17.3)(@types/react@18.0.0)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/core-bentley': 4.9.6
       '@itwin/core-common': 4.9.6(@itwin/core-bentley@4.9.6)(@itwin/core-geometry@4.9.6)
-      '@itwin/core-frontend': 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.1)(reflect-metadata@0.1.14)
+      '@itwin/core-frontend': 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.2)(reflect-metadata@0.1.14)
       '@itwin/core-react': 4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@types/react@18.0.0)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/imodel-components-react': 4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/components-react@4.17.3)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-frontend@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-quantity@4.9.6)(@itwin/core-react@4.17.3)(@types/react@18.0.0)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/itwinui-icons-react': 2.9.0(react-dom@18.3.1)(react@18.3.1)
@@ -1955,7 +1962,7 @@ packages:
     dependencies:
       '@itwin/core-bentley': 4.9.6
       '@itwin/core-common': 4.9.6(@itwin/core-bentley@4.9.6)(@itwin/core-geometry@4.9.6)
-      '@itwin/core-frontend': 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.1)(reflect-metadata@0.1.14)
+      '@itwin/core-frontend': 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.2)(reflect-metadata@0.1.14)
       '@itwin/core-quantity': 4.9.6(@itwin/core-bentley@4.9.6)
       '@itwin/ecschema-metadata': 4.9.6(@itwin/core-bentley@4.9.6)(@itwin/core-quantity@4.9.6)
       '@itwin/presentation-common': 4.9.6(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-quantity@4.9.6)(@itwin/ecschema-metadata@4.9.6)
@@ -1982,13 +1989,13 @@ packages:
       - debug
     dev: false
 
-  /@itwin/service-authorization@1.2.2(@itwin/core-bentley@4.10.5)(@itwin/core-geometry@4.10.5):
+  /@itwin/service-authorization@1.2.2(@itwin/core-bentley@4.10.7)(@itwin/core-geometry@4.10.7):
     resolution: {integrity: sha512-WiMqdSTcytAoC6X7pPZr847JzP1AUZJI45npkiEPFHV5S44z0fjMndvRF7hyqNqeMP6EcgeJuaoby17gtJKrQQ==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0 || ^4.0.0
     dependencies:
-      '@itwin/core-bentley': 4.10.5
-      '@itwin/core-common': 4.9.6(@itwin/core-bentley@4.10.5)(@itwin/core-geometry@4.10.5)
+      '@itwin/core-bentley': 4.10.7
+      '@itwin/core-common': 4.9.6(@itwin/core-bentley@4.10.7)(@itwin/core-geometry@4.10.7)
       got: 12.6.1
       jsonwebtoken: 9.0.2
       jwks-rsa: 2.1.5
@@ -2050,11 +2057,11 @@ packages:
       '@bentley/icons-generic-webfont': 1.0.34
       '@itwin/appui-abstract': 4.9.6(@itwin/core-bentley@4.9.6)
       '@itwin/appui-layout-react': 4.8.3(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-react@4.17.3)(@types/react@18.0.0)(react-dom@18.3.1)(react@18.3.1)
-      '@itwin/appui-react': 4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/components-react@4.17.3)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-frontend@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-quantity@4.9.6)(@itwin/core-react@4.17.3)(@itwin/core-telemetry@4.10.5)(@itwin/imodel-components-react@4.17.3)(@types/react@18.0.0)(react-dom@18.3.1)(react-redux@8.1.3)(react@18.3.1)(redux@4.2.1)
+      '@itwin/appui-react': 4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/components-react@4.17.3)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-frontend@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-quantity@4.9.6)(@itwin/core-react@4.17.3)(@itwin/core-telemetry@4.10.7)(@itwin/imodel-components-react@4.17.3)(@types/react@18.0.0)(react-dom@18.3.1)(react-redux@8.1.3)(react@18.3.1)(redux@4.2.1)
       '@itwin/components-react': 4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-react@4.17.3)(@types/react@18.0.0)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/core-bentley': 4.9.6
       '@itwin/core-common': 4.9.6(@itwin/core-bentley@4.9.6)(@itwin/core-geometry@4.9.6)
-      '@itwin/core-frontend': 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.1)(reflect-metadata@0.1.14)
+      '@itwin/core-frontend': 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.2)(reflect-metadata@0.1.14)
       '@itwin/core-geometry': 4.9.6
       '@itwin/core-react': 4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@types/react@18.0.0)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/imodels-access-frontend': 4.1.6(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-frontend@4.9.6)
@@ -2094,7 +2101,7 @@ packages:
     dependencies:
       '@itwin/core-bentley': 4.9.6
       '@itwin/core-common': 4.9.6(@itwin/core-bentley@4.9.6)(@itwin/core-geometry@4.9.6)
-      '@itwin/core-frontend': 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.1)(reflect-metadata@0.1.14)
+      '@itwin/core-frontend': 4.9.6(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-geometry@4.9.6)(@itwin/core-orbitgt@4.9.6)(@itwin/core-quantity@4.9.6)(inversify@6.2.2)(reflect-metadata@0.1.14)
       '@itwin/core-react': 4.17.3(@itwin/appui-abstract@4.9.6)(@itwin/core-bentley@4.9.6)(@types/react@18.0.0)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/imodels-client-management': 5.9.0
       '@itwin/presentation-common': 4.9.6(@itwin/core-bentley@4.9.6)(@itwin/core-common@4.9.6)(@itwin/core-quantity@4.9.6)(@itwin/ecschema-metadata@4.9.6)
@@ -2256,7 +2263,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.17.1
+      fastq: 1.19.1
     dev: true
 
   /@openid/appauth@1.3.2:
@@ -2881,7 +2888,7 @@ packages:
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      semver: 7.6.3
+      semver: 7.7.1
       ts-api-utils: 1.4.0(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
@@ -3022,7 +3029,7 @@ packages:
       debug: 4.3.7(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.3
+      semver: 7.7.1
       tsutils: 3.21.0(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
@@ -3044,7 +3051,7 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.6.3
+      semver: 7.7.1
       ts-api-utils: 1.4.0(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
@@ -3066,7 +3073,7 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.6.3
+      semver: 7.7.1
       ts-api-utils: 1.4.0(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
@@ -3106,7 +3113,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.1.6)
       eslint: 8.57.1
-      semver: 7.6.3
+      semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3125,7 +3132,7 @@ packages:
       '@typescript-eslint/types': 7.0.2
       '@typescript-eslint/typescript-estree': 7.0.2(typescript@5.1.6)
       eslint: 8.57.1
-      semver: 7.6.3
+      semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3655,12 +3662,12 @@ packages:
       is-buffer: 2.0.5
     dev: true
 
-  /axios-mock-adapter@1.22.0(axios@1.7.9):
+  /axios-mock-adapter@1.22.0(axios@1.8.1):
     resolution: {integrity: sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==}
     peerDependencies:
       axios: '>= 0.17.0'
     dependencies:
-      axios: 1.7.9
+      axios: 1.8.1
       fast-deep-equal: 3.1.3
       is-buffer: 2.0.5
     dev: true
@@ -3684,11 +3691,11 @@ packages:
     transitivePeerDependencies:
       - debug
 
-  /axios@1.7.9:
-    resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
+  /axios@1.8.1:
+    resolution: {integrity: sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==}
     dependencies:
       follow-redirects: 1.15.9
-      form-data: 4.0.1
+      form-data: 4.0.2
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -3733,6 +3740,27 @@ packages:
       toposort: 2.0.2
       uuid: 9.0.1
       workspace-tools: 0.38.0
+      yargs-parser: 21.1.1
+    transitivePeerDependencies:
+      - typescript
+    dev: true
+
+  /beachball@2.51.0:
+    resolution: {integrity: sha512-Io+mzUb2QnTeOFDzyho0woU6FnUf1UlJLljJUIyMMJqxxj/sflXe5/CKnWk1c00FGRjMyftSx7oo7fD4Rf3ZEw==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    dependencies:
+      cosmiconfig: 8.3.6(typescript@5.1.6)
+      execa: 5.1.1
+      fs-extra: 11.3.0
+      lodash: 4.17.21
+      minimatch: 3.1.2
+      p-graph: 1.1.2
+      p-limit: 3.1.0
+      prompts: 2.4.2
+      semver: 7.7.1
+      toposort: 2.0.2
+      workspace-tools: 0.38.1
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - typescript
@@ -3932,6 +3960,14 @@ packages:
       make-dir: 3.1.0
       package-hash: 4.0.0
       write-file-atomic: 3.0.3
+    dev: true
+
+  /call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
     dev: true
 
   /call-bind@1.0.7:
@@ -4183,7 +4219,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@types/parse-json': 4.0.2
-      import-fresh: 3.3.0
+      import-fresh: 3.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
@@ -4198,7 +4234,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      import-fresh: 3.3.0
+      import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
@@ -4275,6 +4311,15 @@ packages:
 
   /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+    engines: {node: '>= 8'}
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+    dev: true
+
+  /cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
     dependencies:
       path-key: 3.1.1
@@ -4545,6 +4590,15 @@ packages:
     resolution: {integrity: sha512-JVuNV0EJzD3LBYhGyIXJLeBID/EVtmFO1ZNhAYflTgiMiAJlbhXQmRRda/azjc8MRVMHh0gqGhiqHUo5dIXM8Q==}
     dev: false
 
+  /dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+    dev: true
+
   /duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
     dev: true
@@ -4686,6 +4740,11 @@ packages:
       get-intrinsic: 1.2.4
     dev: true
 
+  /es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
   /es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
@@ -4723,11 +4782,28 @@ packages:
       es-errors: 1.3.0
     dev: true
 
+  /es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+    dev: true
+
   /es-set-tostringtag@2.0.3:
     resolution: {integrity: sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       get-intrinsic: 1.2.4
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+    dev: true
+
+  /es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
     dev: true
@@ -4930,7 +5006,7 @@ packages:
       espree: 10.3.0
       esquery: 1.6.0
       parse-imports: 2.2.1
-      semver: 7.6.3
+      semver: 7.7.1
       spdx-expression-parse: 4.0.0
       synckit: 0.9.2
     transitivePeerDependencies:
@@ -5165,7 +5241,7 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 6.0.1
       human-signals: 2.1.0
       is-stream: 2.0.1
@@ -5223,8 +5299,8 @@ packages:
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  /fast-glob@3.3.2:
-    resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
+  /fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -5259,10 +5335,10 @@ packages:
     engines: {node: '>= 4.9.1'}
     dev: true
 
-  /fastq@1.17.1:
-    resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
+  /fastq@1.19.1:
+    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
     dependencies:
-      reusify: 1.0.4
+      reusify: 1.1.0
     dev: true
 
   /file-entry-cache@6.0.1:
@@ -5367,7 +5443,7 @@ packages:
     resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       signal-exit: 3.0.7
     dev: true
 
@@ -5391,6 +5467,16 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+
+  /form-data@4.0.2:
+    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      mime-types: 2.1.35
+    dev: true
 
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -5421,6 +5507,15 @@ packages:
 
   /fs-extra@11.2.0:
     resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
+    engines: {node: '>=14.14'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+    dev: true
+
+  /fs-extra@11.3.0:
+    resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
     engines: {node: '>=14.14'}
     dependencies:
       graceful-fs: 4.2.11
@@ -5513,9 +5608,33 @@ packages:
       hasown: 2.0.2
     dev: true
 
+  /get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+    dev: true
+
   /get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
+    dev: true
+
+  /get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
     dev: true
 
   /get-stream@4.1.0:
@@ -5542,7 +5661,7 @@ packages:
   /git-up@7.0.0:
     resolution: {integrity: sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==}
     dependencies:
-      is-ssh: 1.4.0
+      is-ssh: 1.4.1
       parse-url: 8.1.0
     dev: true
 
@@ -5665,7 +5784,7 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
@@ -5675,6 +5794,11 @@ packages:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
       get-intrinsic: 1.2.4
+    dev: true
+
+  /gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
     dev: true
 
   /got@12.6.1:
@@ -5723,6 +5847,11 @@ packages:
 
   /has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
     dev: true
 
@@ -5865,8 +5994,8 @@ packages:
     resolution: {integrity: sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==}
     dev: false
 
-  /import-fresh@3.3.0:
-    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
+  /import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
     dependencies:
       parent-module: 1.0.1
@@ -5925,8 +6054,8 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
-  /inversify@6.2.1(reflect-metadata@0.1.14):
-    resolution: {integrity: sha512-W6Xi0icXIiC48RWdT681+GlZVgAKmCrNTiP7hj4IVPFbcxHz+Jj8Gxz5qr/Az2cgcZMYdB8tKIr2e68LUi1LYQ==}
+  /inversify@6.2.2(reflect-metadata@0.1.14):
+    resolution: {integrity: sha512-KB836KHbZ9WrUnB8ax5MtadOwnqQYa+ZJO3KWbPFgcr4RIEnHM621VaqFZzOZd9+U7ln6upt9n0wJei7x2BNqw==}
     peerDependencies:
       reflect-metadata: ~0.2.2
     dependencies:
@@ -6112,10 +6241,10 @@ packages:
       call-bind: 1.0.7
     dev: true
 
-  /is-ssh@1.4.0:
-    resolution: {integrity: sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==}
+  /is-ssh@1.4.1:
+    resolution: {integrity: sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==}
     dependencies:
-      protocols: 2.0.1
+      protocols: 2.0.2
     dev: true
 
   /is-stream@1.1.0:
@@ -6234,7 +6363,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       archy: 1.0.0
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       istanbul-lib-coverage: 3.2.2
       p-map: 3.0.0
       rimraf: 3.0.2
@@ -6429,7 +6558,7 @@ packages:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /jsx-ast-utils@3.3.5:
@@ -6675,7 +6804,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /map-age-cleaner@0.1.3:
@@ -6689,6 +6818,11 @@ packages:
     resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
     engines: {node: '>= 12'}
     hasBin: true
+    dev: true
+
+  /math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
     dev: true
 
   /md5.js@1.3.5:
@@ -6962,7 +7096,7 @@ packages:
     resolution: {integrity: sha512-SZ40vRiy/+wRTf21hxkkEjPJZpARzUMVcJoQse2EF8qkUWbbO2z7vd5oA/H6bVH6SZQ5STGcu0KRDS7biNRfxw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.1
     dev: false
 
   /node-addon-api@4.3.0:
@@ -7310,16 +7444,16 @@ packages:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
-  /parse-path@7.0.0:
-    resolution: {integrity: sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==}
+  /parse-path@7.0.1:
+    resolution: {integrity: sha512-6ReLMptznuuOEzLoGEa+I1oWRSj2Zna5jLWC+l6zlfAI4dbbSaIES29ThzuPkbhNahT65dWzfoZEO6cfJw2Ksg==}
     dependencies:
-      protocols: 2.0.1
+      protocols: 2.0.2
     dev: true
 
   /parse-url@8.1.0:
     resolution: {integrity: sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==}
     dependencies:
-      parse-path: 7.0.0
+      parse-path: 7.0.1
     dev: true
 
   /parseurl@1.3.3:
@@ -7504,8 +7638,8 @@ packages:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  /protocols@2.0.1:
-    resolution: {integrity: sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==}
+  /protocols@2.0.2:
+    resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
     dev: true
 
   /proxy-addr@2.0.7:
@@ -7802,7 +7936,7 @@ packages:
   /redux@4.2.1:
     resolution: {integrity: sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.26.9
     dev: false
 
   /reflect-metadata@0.1.14:
@@ -7914,8 +8048,8 @@ packages:
       lowercase-keys: 3.0.0
     dev: true
 
-  /reusify@1.0.4:
-    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
+  /reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
     dev: true
 
@@ -8073,6 +8207,12 @@ packages:
 
   /semver@7.6.3:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
+
+  /semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -9158,7 +9298,7 @@ packages:
     resolution: {integrity: sha512-v0UFVvw9BjHtRu2Dau5PEJKkuG8u4jPlpXZQWjSz9XgbSutpPURqtO2P0hp3cVmQVATh8lkMFCewFgJuDnyC/w==}
     dependencies:
       '@yarnpkg/lockfile': 1.1.0
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       git-url-parse: 13.1.1
       globby: 11.1.0
       jju: 1.4.0
@@ -9170,7 +9310,19 @@ packages:
     resolution: {integrity: sha512-BpvydL36Q+AVBU6Rj/a7nfxfEhxvX4ZkLVCsUx5LJ5UpzIcvLDgxvnolBSY+2MUU8VYhvf+PGtF7eWS8xBC1Iw==}
     dependencies:
       '@yarnpkg/lockfile': 1.1.0
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
+      git-url-parse: 13.1.1
+      globby: 11.1.0
+      jju: 1.4.0
+      js-yaml: 4.1.0
+      micromatch: 4.0.8
+    dev: true
+
+  /workspace-tools@0.38.1:
+    resolution: {integrity: sha512-EZWlrYrZcxd4XRQOMnARo9DOBRT37XWfGkRz+mTOH8z+WKJBgtovRjyVbWhdTe/8DkthrHa8v30FOjCAE021AA==}
+    dependencies:
+      '@yarnpkg/lockfile': 1.1.0
+      fast-glob: 3.3.3
       git-url-parse: 13.1.1
       globby: 11.1.0
       jju: 1.4.0

--- a/python/reality_apis/RC/rcs_settings.py
+++ b/python/reality_apis/RC/rcs_settings.py
@@ -44,11 +44,16 @@ class ConversionSettings:
             settings_dict["inputs"].append({"id": rd_id})
         for rd_id in self.inputs.e57:
             settings_dict["inputs"].append({"id": rd_id})
+        for rd_id in self.inputs.opc:
+            settings_dict["inputs"].append({"id": rd_id})
+        for rd_id in self.inputs.pointcloud:
+            settings_dict["inputs"].append({"id": rd_id})
 
         if self.outputs.opc:
             settings_dict["outputs"].append("OPC")
         if self.outputs.pnts:
             settings_dict["outputs"].append("PNTS")
+
 
         if self.options.engines > 0:
             settings_dict["options"]["processingEngines"] = self.options.engines
@@ -79,6 +84,10 @@ class ConversionSettings:
                     new_job_settings.inputs.ply.append(input_dict["id"])
                 elif input_dict["type"] == "E57":
                     new_job_settings.inputs.e57.append(input_dict["id"])
+                elif input_dict["type"] == "OPC":
+                    new_job_settings.inputs.opc.append(input_dict["id"])
+                elif input_dict["type"] == "PointCloud":
+                    new_job_settings.inputs.pointcloud.append(input_dict["id"])
                 else:
                     raise TypeError(
                         "found non expected input type:" + input_dict["type"]
@@ -115,6 +124,8 @@ class ConversionSettings:
             laz: A list of paths to LAZ files.
             ply: A list of paths to PLY files.
             e57: A list of paths to E57 files.
+            opc: A list of paths to OPC files.
+            pointcloud: A list of paths to PointCloud files.
         """
 
         def __init__(self) -> None:
@@ -122,6 +133,8 @@ class ConversionSettings:
             self.laz: List[str] = []
             self.ply: List[str] = []
             self.e57: List[str] = []
+            self.opc: List[str] = []
+            self.pointcloud: List[str] = []
 
     class Outputs:
         """

--- a/python/reality_apis/RC/rcs_settings.py
+++ b/python/reality_apis/RC/rcs_settings.py
@@ -54,7 +54,6 @@ class ConversionSettings:
         if self.outputs.pnts:
             settings_dict["outputs"].append("PNTS")
 
-
         if self.options.engines > 0:
             settings_dict["options"]["processingEngines"] = self.options.engines
         if not self.options.merge:

--- a/python/reality_apis/RC/rcs_settings.py
+++ b/python/reality_apis/RC/rcs_settings.py
@@ -53,6 +53,10 @@ class ConversionSettings:
             settings_dict["outputs"].append("OPC")
         if self.outputs.pnts:
             settings_dict["outputs"].append("PNTS")
+        if self.outputs.glb:
+            settings_dict["outputs"].append("GLB")
+        if self.outputs.glbc:
+            settings_dict["outputs"].append("GLBC")
 
         if self.options.engines > 0:
             settings_dict["options"]["processingEngines"] = self.options.engines
@@ -101,6 +105,12 @@ class ConversionSettings:
                 elif output_dict["type"] == "PNTS":
                     new_job_settings.outputs.pnts = []
                     new_job_settings.outputs.pnts.append(output_dict["id"])
+                elif output_dict["type"] == "GLB":
+                    new_job_settings.outputs.glb = []
+                    new_job_settings.outputs.glb.append(output_dict["id"])
+                elif output_dict["type"] == "GLBC":
+                    new_job_settings.outputs.glbc = []
+                    new_job_settings.outputs.glbc.append(output_dict["id"])
                 else:
                     raise TypeError(
                         "found non expected output type" + output_dict["type"]
@@ -142,11 +152,15 @@ class ConversionSettings:
         Attributes:
             opc: Either a boolean to indicate conversion type or a list of created OPC files ids.
             pnts: Either a boolean to indicate conversion type or a list of created PNTS files ids.
+            glb: Either a boolean to indicate conversion type or a list of created PNTS files ids.
+            glbc: Either a boolean to indicate conversion type or a list of created PNTS files ids.
         """
 
         def __init__(self) -> None:
             self.opc: Union[bool, List[str]] = False
             self.pnts: Union[bool, List[str]] = False
+            self.glb: Union[bool, List[str]] = False
+            self.glbc: Union[bool, List[str]] = False
 
     class Options:
         """

--- a/python/reality_apis/utils.py
+++ b/python/reality_apis/utils.py
@@ -36,6 +36,7 @@ class RealityDataType(Enum):
     GeoJSON = "GeoJSON"
     OVT = "OVT"
     OVF = "OVF"
+    PointCloud = "PointCloud"
     Unstructured = "Unstructured"
 
 


### PR DESCRIPTION
This PR helps running running current RCS test pipeline - which will run jobs requesting output- GLB, GLBC and 2 new inputs- OPC, PointCloud since that pipeline use this python SDK.

Added 2 new Outputs and 2 Inputs support for RCS in python SDK
2 outputs type: GLB and GLBC
2 inputs type: OPC and PointCloud(POD)

Note: In Reality Management the POD is stored as PointCloud type.

