### PR TITLE
Fixed naming problem for S3D specs

### DIFF
--- a/python_sdk/src/reality_capture/specifications/segmentation3d.py
+++ b/python_sdk/src/reality_capture/specifications/segmentation3d.py
@@ -19,7 +19,7 @@ class Segmentation3DInputs(BaseModel):
                                                       "pointing to a segmented point cloud, "
                                                       "this input replaces point_cloud_segmentation_detector, "
                                                       "point_clouds and meshes inputs")
-    extent: Optional[str] = Field(None, alias="clipPolygon", pattern=r"^bkt:.+",
+    extent: Optional[str] = Field(None, alias="extent", pattern=r"^bkt:.+",
                                   description="Path in the bucket of the clipping polygon to apply")
 
 


### PR DESCRIPTION
The alias for S3D "extent" was still the old one "clipPolygon"