### PR TITLE
Add TrainingCD3D job type and pointCloudChangeDetector to SDKs

### DIFF
--- a/python_sdk/src/reality_capture/service/job.py
+++ b/python_sdk/src/reality_capture/service/job.py
@@ -28,7 +28,8 @@ from reality_capture.specifications.water_constraints import (WaterConstraintsSp
                                                               WaterConstraintsSpecificationsCreate)
 """from reality_capture.specifications.point_cloud_conversion import (PointCloudConversionSpecificationsCreate,
                                                                    PointCloudConversionSpecifications)"""
-from reality_capture.specifications.training import (TrainingS3DSpecificationsCreate, TrainingS3DSpecifications)
+from reality_capture.specifications.training import (TrainingS3DSpecificationsCreate, TrainingS3DSpecifications,
+                                                     TrainingCD3DSpecificationsCreate, TrainingCD3DSpecifications)
 from reality_capture.specifications.gaussian_splats import (GaussianSplatsSpecificationsCreate,
                                                             GaussianSplatsSpecifications)
 from reality_capture.specifications.eval_o2d import (EvalO2DSpecificationsCreate, EvalO2DSpecifications)
@@ -63,6 +64,7 @@ class JobType(Enum):
     TOUCH_UP_EXPORT = "TouchUpExport"
     WATER_CONSTRAINTS = "WaterConstraints"
     TRAINING_S3D = "TrainingS3D"
+    TRAINING_CD3D = "TrainingCD3D"
     # POINT_CLOUD_CONVERSION = "PointCloudConversion"
 
 class Service(Enum):
@@ -78,7 +80,7 @@ def _get_appropriate_service(jt: JobType):
         return Service.MODELING
     if jt in [JobType.OBJECTS_2D, JobType.SEGMENTATION_2D, JobType.SEGMENTATION_3D, JobType.SEGMENTATION_ORTHOPHOTO,
             JobType.CHANGE_DETECTION, JobType.EVAL_O2D, JobType.EVAL_O3D, JobType.EVAL_S2D,
-            JobType.EVAL_S3D, JobType.EVAL_SORTHO, JobType.TRAINING_S3D]:
+            JobType.EVAL_S3D, JobType.EVAL_SORTHO, JobType.TRAINING_S3D, JobType.TRAINING_CD3D]:
         return Service.ANALYSIS
     # return Service.CONVERSION
     raise NotImplementedError("Other services not yet implemented")
@@ -109,7 +111,7 @@ class JobCreate(BaseModel):
                         Segmentation3DSpecificationsCreate, SegmentationOrthophotoSpecificationsCreate,
                         TilingSpecificationsCreate, TouchUpExportSpecificationsCreate,
                         TouchUpImportSpecificationsCreate, WaterConstraintsSpecificationsCreate,
-                        TrainingS3DSpecificationsCreate] = (
+                        TrainingS3DSpecificationsCreate, TrainingCD3DSpecificationsCreate] = (
         Field(description="Specifications aligned with the job type."))
     itwin_id: str = Field(description="iTwin ID, used by the service for finding "
                                       "input reality data and uploading output data.",
@@ -154,7 +156,7 @@ class Job(BaseModel):
                         Segmentation3DSpecifications, SegmentationOrthophotoSpecifications,
                         TilingSpecifications, TouchUpExportSpecifications,
                         TouchUpImportSpecifications, WaterConstraintsSpecifications,
-                        TrainingS3DSpecifications] = (
+                        TrainingS3DSpecifications, TrainingCD3DSpecifications] = (
         Field(description="Specifications aligned with the job type."))
 
     @field_validator("specifications", mode="plain")
@@ -208,6 +210,8 @@ class Job(BaseModel):
             specifications = WaterConstraintsSpecifications(**raw_dict)
         elif job_type == JobType.TRAINING_S3D:
             specifications = TrainingS3DSpecifications(**raw_dict)
+        elif job_type == JobType.TRAINING_CD3D:
+            specifications = TrainingCD3DSpecifications(**raw_dict)
         else:
             raise ValueError(f"Unsupported job type: {job_type}")
 

--- a/python_sdk/src/reality_capture/specifications/change_detection.py
+++ b/python_sdk/src/reality_capture/specifications/change_detection.py
@@ -6,6 +6,9 @@ from enum import Enum
 class ChangeDetectionInputs(BaseModel):
     model_3d_a: str = Field(alias="model3DA", description="Reality data id of ContextScene, point cloud, Gaussian splats, or mesh")
     model_3d_b: str = Field(alias="model3DB", description="Reality data id of ContextScene, point cloud, Gaussian splats, or mesh")
+    point_cloud_change_detector: Optional[str] = Field(None, alias="pointCloudChangeDetector",
+                                                       description="Reality data id of change detection detector "
+                                                                   "OR identifier from AI Detectors library")
     extent: Optional[str] = Field(None, alias="extent", pattern=r"^bkt:.+",
                                   description="Path in the bucket of the clipping polygon to apply")
     preset: Optional[str] = Field(None, alias="preset", pattern=r"^bkt:.+",
@@ -31,7 +34,6 @@ class ChangeDetectionOutputs(BaseModel):
                                                 description="Reality data id of locations of changes in B as SHP format")
     locations3d_b_as_geojson: Optional[str] = Field(None, alias="locations3DBAsGeoJSON",
                                                     description="Reality data id of locations of changes in B as GeoJSON file")
-    
 
 
 class ChangeDetectionOutputsCreate(Enum):
@@ -45,7 +47,7 @@ class ChangeDetectionOutputsCreate(Enum):
     LOCATIONS3D_B = "locations3DB"
     LOCATIONS3D_B_AS_SHP = "locations3DBAsSHP"
     LOCATIONS3D_B_AS_GEOJSON = "locations3DBAsGeoJSON"
-    
+
 
 class ChangeDetectionOptions(BaseModel):
     min_points_per_change: Optional[int] = Field(None, alias="minPointsPerChange",

--- a/python_sdk/src/reality_capture/specifications/training.py
+++ b/python_sdk/src/reality_capture/specifications/training.py
@@ -59,3 +59,65 @@ class TrainingS3DSpecifications(BaseModel):
     inputs: TrainingS3DInputs = Field(description="Inputs")
     outputs: TrainingS3DOutputs = Field(description="Outputs")
     options: Optional[TrainingS3DOptions] = Field(None, description="Options")
+
+
+class Segmentation3DPair(BaseModel):
+    segmentation_3d_a: str = Field(
+        alias="segmentation3DA",
+        description="Reality data id of ContextScene pointing to a segmented 3D model (time A)"
+    )
+    segmentation_3d_b: str = Field(
+        alias="segmentation3DB",
+        description="Reality data id of ContextScene pointing to a segmented 3D model (time B)"
+    )
+
+
+class TrainingCD3DInputs(BaseModel):
+    segmentation_3d_pairs: list[Segmentation3DPair] = Field(
+        alias="segmentation3DPairs",
+        description="List of paired segmented 3D scenes for change detection training."
+    )
+    preset: Optional[str] = Field(default=None, description="Path to a preset")
+    detector_name: str = Field(description="Name of the detector to train", alias="detectorName")
+
+
+class TrainingCD3DOutputs(BaseModel):
+    detector: str = Field(description="Full detector information (name/version)")
+
+
+class TrainingCD3DOutputsCreate(Enum):
+    DETECTOR = "detector"
+
+
+class TrainingCD3DOptions(BaseModel):
+    epochs: Optional[int] = Field(
+        None, description="Number of times to iterate over the entire dataset", ge=1, le=100
+    )
+    spacing: Optional[float] = Field(
+        None,
+        description="Spacing of the point cloud seen by the detector (in meters).",
+        gt=0
+    )
+    features: Optional[list[PointCloudFeature]] = Field(None, description="Features to use for the training.")
+    ignore_class: Optional[int] = Field(
+        None, alias="ignoreClass",
+        description="Class index to ignore during training."
+    )
+    version_number: Optional[str] = Field(
+        None,
+        description="String representing the version number for the newly trained detector.",
+        alias="versionNumber",
+        pattern=r"^\d+(?:\.\d+)?$"
+    )
+
+
+class TrainingCD3DSpecificationsCreate(BaseModel):
+    inputs: TrainingCD3DInputs = Field(description="Inputs")
+    outputs: list[TrainingCD3DOutputsCreate] = Field(description="Outputs")
+    options: Optional[TrainingCD3DOptions] = Field(None, description="Options")
+
+
+class TrainingCD3DSpecifications(BaseModel):
+    inputs: TrainingCD3DInputs = Field(description="Inputs")
+    outputs: TrainingCD3DOutputs = Field(description="Outputs")
+    options: Optional[TrainingCD3DOptions] = Field(None, description="Options")

--- a/python_sdk/tests/test_job_validator.py
+++ b/python_sdk/tests/test_job_validator.py
@@ -19,6 +19,7 @@ from reality_capture.specifications.segmentation_orthophoto import SegmentationO
 from reality_capture.specifications.tiling import TilingSpecifications
 from reality_capture.specifications.touchup import TouchUpImportSpecifications, TouchUpExportSpecifications
 from reality_capture.specifications.water_constraints import WaterConstraintsSpecifications
+from reality_capture.specifications.training import TrainingCD3DSpecifications
 import pytest
 from unittest.mock import patch, MagicMock
 import reality_capture.service.job as job_module
@@ -373,4 +374,47 @@ class TestJobValidator:
                 Job, j["specifications"], MagicMock(data={"type": unsupported})
             )
         assert "Unsupported job type" in str(exc_info.value)
+
+    def test_validation_training_cd3d(self):
+        j = self.j_base.copy()
+        j["type"] = "TrainingCD3D"
+        j["specifications"] = {
+            "inputs": {
+                "segmentation3DPairs": [
+                    {"segmentation3DA": "rdid_t0_a", "segmentation3DB": "rdid_t1_a"},
+                    {"segmentation3DA": "rdid_t0_b", "segmentation3DB": "rdid_t1_b"}
+                ],
+                "detectorName": "qa-cdptv3-test"
+            },
+            "outputs": {
+                "detector": "detector_rdid"
+            },
+            "options": {
+                "epochs": 5,
+                "spacing": 0.2,
+                "features": ["RGB", "INTENSITY"],
+                "ignoreClass": -100,
+                "versionNumber": "1.0"
+            }
+        }
+        job = Job(**j)
+        assert isinstance(job.specifications, TrainingCD3DSpecifications)
+        assert len(job.specifications.inputs.segmentation_3d_pairs) == 2
+        assert job.specifications.inputs.segmentation_3d_pairs[0].segmentation_3d_a == "rdid_t0_a"
+        assert job.specifications.inputs.segmentation_3d_pairs[0].segmentation_3d_b == "rdid_t1_a"
+        assert job.specifications.inputs.detector_name == "qa-cdptv3-test"
+        assert job.specifications.outputs.detector == "detector_rdid"
+        assert job.specifications.options.epochs == 5
+        assert job.specifications.options.spacing == 0.2
+        assert job.specifications.options.ignore_class == -100
+        assert job.specifications.options.version_number == "1.0"
+
+        # Verify camelCase serialization round-trip
+        dumped = job.specifications.model_dump(by_alias=True)
+        assert "segmentation3DPairs" in dumped["inputs"]
+        assert "segmentation3DA" in dumped["inputs"]["segmentation3DPairs"][0]
+        assert "segmentation3DB" in dumped["inputs"]["segmentation3DPairs"][0]
+        assert "detectorName" in dumped["inputs"]
+        assert "ignoreClass" in dumped["options"]
+        assert "versionNumber" in dumped["options"]
 

--- a/typescript/packages/reality-capture/src/service/job.ts
+++ b/typescript/packages/reality-capture/src/service/job.ts
@@ -15,6 +15,7 @@ import { TilingSpecificationsCreateSchema, TilingSpecificationsSchema } from "..
 import { TouchUpExportSpecificationsCreateSchema, TouchUpImportSpecificationsCreateSchema, TouchUpExportSpecificationsSchema, TouchUpImportSpecificationsSchema } from "../specifications/touchup";
 import { WaterConstraintsSpecificationsCreateSchema, WaterConstraintsSpecificationsSchema } from "../specifications/water_constraints";
 import { TrainingS3DSpecificationsCreateSchema, TrainingS3DSpecificationsSchema } from "../specifications/training";
+import { TrainingCD3DSpecificationsCreateSchema, TrainingCD3DSpecificationsSchema } from "../specifications/training";
 //import { PointCloudConversionSpecificationsCreateSchema, PointCloudConversionSpecificationsSchema } from '../specifications/point_cloud_conversion';
 import { GaussianSplatsSpecificationsCreateSchema, GaussianSplatsSpecificationsSchema } from "../specifications/gaussian_splats";
 import { EvalO2DSpecificationsCreateSchema, EvalO2DSpecificationsSchema } from "../specifications/eval_o2d";
@@ -44,6 +45,7 @@ export enum JobType {
   SEGMENTATION_ORTHOPHOTO = "SegmentationOrthophoto",
   TILING = "Tiling",
   TRAINING_S3D = "TrainingS3D",
+  TRAINING_CD3D = "TrainingCD3D",
   TOUCH_UP_IMPORT = "TouchUpImport",
   TOUCH_UP_EXPORT = "TouchUpExport",
   WATER_CONSTRAINTS = "WaterConstraints",
@@ -69,7 +71,7 @@ export function getAppropriateService(jt: JobType): Service {
     JobType.OBJECTS_2D, JobType.SEGMENTATION_2D, JobType.SEGMENTATION_3D,
     JobType.SEGMENTATION_ORTHOPHOTO, JobType.CHANGE_DETECTION,
     JobType.EVAL_O2D, JobType.EVAL_O3D, JobType.EVAL_S2D, JobType.EVAL_S3D,
-    JobType.EVAL_SORTHO, JobType.TRAINING_S3D,
+    JobType.EVAL_SORTHO, JobType.TRAINING_S3D, JobType.TRAINING_CD3D,
   ].includes(jt)) {
     return Service.ANALYSIS;
   }
@@ -114,6 +116,7 @@ export const JobCreateSchema = z.object({
     WaterConstraintsSpecificationsCreateSchema,
     //PointCloudConversionSpecificationsCreateSchema,
     TrainingS3DSpecificationsCreateSchema,
+    TrainingCD3DSpecificationsCreateSchema,
   ]).describe("Specifications aligned with the job type."),
   iTwinId: z.string().describe("iTwin ID, used by the service for finding input reality data and uploading output data."),
 });
@@ -231,6 +234,11 @@ export const JobSchema = z.discriminatedUnion("type", [
     ...CommonFields,
     type: z.literal("TrainingS3D"),
     specifications: TrainingS3DSpecificationsSchema,
+  }),
+  z.object({
+    ...CommonFields,
+    type: z.literal("TrainingCD3D"),
+    specifications: TrainingCD3DSpecificationsSchema,
   }),
   z.object({
     ...CommonFields,

--- a/typescript/packages/reality-capture/src/service/job.ts
+++ b/typescript/packages/reality-capture/src/service/job.ts
@@ -14,8 +14,7 @@ import { SegmentationOrthophotoSpecificationsCreateSchema, SegmentationOrthophot
 import { TilingSpecificationsCreateSchema, TilingSpecificationsSchema } from "../specifications/tiling";
 import { TouchUpExportSpecificationsCreateSchema, TouchUpImportSpecificationsCreateSchema, TouchUpExportSpecificationsSchema, TouchUpImportSpecificationsSchema } from "../specifications/touchup";
 import { WaterConstraintsSpecificationsCreateSchema, WaterConstraintsSpecificationsSchema } from "../specifications/water_constraints";
-import { TrainingS3DSpecificationsCreateSchema, TrainingS3DSpecificationsSchema } from "../specifications/training";
-import { TrainingCD3DSpecificationsCreateSchema, TrainingCD3DSpecificationsSchema } from "../specifications/training";
+import { TrainingS3DSpecificationsCreateSchema, TrainingS3DSpecificationsSchema, TrainingCD3DSpecificationsCreateSchema, TrainingCD3DSpecificationsSchema } from "../specifications/training";
 //import { PointCloudConversionSpecificationsCreateSchema, PointCloudConversionSpecificationsSchema } from '../specifications/point_cloud_conversion';
 import { GaussianSplatsSpecificationsCreateSchema, GaussianSplatsSpecificationsSchema } from "../specifications/gaussian_splats";
 import { EvalO2DSpecificationsCreateSchema, EvalO2DSpecificationsSchema } from "../specifications/eval_o2d";

--- a/typescript/packages/reality-capture/src/specifications/change_detection.ts
+++ b/typescript/packages/reality-capture/src/specifications/change_detection.ts
@@ -20,6 +20,12 @@ export const ChangeDetectionInputsSchema = z.object({
   model3DB: z
     .string()
     .describe("Reality data id of ContextScene, point cloud, GS or mesh"),
+  pointCloudChangeDetector: z
+    .string()
+    .optional()
+    .describe(
+      "Reality data id of change detection detector OR identifier from AI Detectors library",
+    ),
   extent: z
     .string()
     .describe("Path in the bucket of the clipping polygon to apply")

--- a/typescript/packages/reality-capture/src/specifications/training.ts
+++ b/typescript/packages/reality-capture/src/specifications/training.ts
@@ -69,3 +69,91 @@ export const TrainingS3DSpecificationsSchema = z.object({
   options: TrainingS3DOptionsSchema.describe("Options").optional(),
 });
 export type TrainingS3DSpecifications = z.infer<typeof TrainingS3DSpecificationsSchema>;
+
+export const Segmentation3DPairSchema = z.object({
+  segmentation3DA: z
+    .string()
+    .describe(
+      "Reality data id of ContextScene pointing to a segmented 3D model (time A)",
+    ),
+  segmentation3DB: z
+    .string()
+    .describe(
+      "Reality data id of ContextScene pointing to a segmented 3D model (time B)",
+    ),
+});
+export type Segmentation3DPair = z.infer<typeof Segmentation3DPairSchema>;
+
+export const TrainingCD3DInputsSchema = z.object({
+  segmentation3DPairs: z
+    .array(Segmentation3DPairSchema)
+    .describe(
+      "List of paired segmented 3D scenes for change detection training.",
+    ),
+  preset: z.string().optional().describe("Path to a preset"),
+  detectorName: z.string().describe("Name of the detector to train"),
+});
+export type TrainingCD3DInputs = z.infer<typeof TrainingCD3DInputsSchema>;
+
+export const TrainingCD3DOutputsSchema = z.object({
+  detector: z.string().describe("Full detector information (name/version)"),
+});
+export type TrainingCD3DOutputs = z.infer<typeof TrainingCD3DOutputsSchema>;
+
+export enum TrainingCD3DOutputsCreate {
+  DETECTOR = "detector",
+}
+
+export const TrainingCD3DOptionsSchema = z.object({
+  epochs: z
+    .number()
+    .int()
+    .gte(1, { message: "Must be greater than or equal to 1" })
+    .lte(100, { message: "Must be less than or equal to 100" })
+    .describe("Number of times to iterate over the entire dataset")
+    .optional(),
+  spacing: z
+    .number()
+    .gt(0, { message: "Must be greater than 0" })
+    .describe(
+      "Spacing of the point cloud seen by the detector (in meters).",
+    )
+    .optional(),
+  features: z
+    .array(z.nativeEnum(PointCloudFeature))
+    .describe("Features to use for the training.")
+    .optional(),
+  ignoreClass: z
+    .number()
+    .int()
+    .describe("Class index to ignore during training.")
+    .optional(),
+  versionNumber: z
+    .string()
+    .regex(/^\d+(?:\.\d+)?$/, "Must be a version like '1' or '1.0'")
+    .describe(
+      "String representing the version number for the newly trained detector.",
+    )
+    .optional(),
+});
+export type TrainingCD3DOptions = z.infer<typeof TrainingCD3DOptionsSchema>;
+
+export const TrainingCD3DSpecificationsCreateSchema = z.object({
+  inputs: TrainingCD3DInputsSchema.describe("Inputs"),
+  outputs: z
+    .array(z.nativeEnum(TrainingCD3DOutputsCreate))
+    .describe("Outputs"),
+  options: TrainingCD3DOptionsSchema.describe("Options").optional(),
+});
+export type TrainingCD3DSpecificationsCreate = z.infer<
+  typeof TrainingCD3DSpecificationsCreateSchema
+>;
+
+export const TrainingCD3DSpecificationsSchema = z.object({
+  inputs: TrainingCD3DInputsSchema.describe("Inputs"),
+  outputs: TrainingCD3DOutputsSchema.describe("Outputs"),
+  options: TrainingCD3DOptionsSchema.describe("Options").optional(),
+});
+export type TrainingCD3DSpecifications = z.infer<
+  typeof TrainingCD3DSpecificationsSchema
+>;

--- a/typescript/packages/reality-capture/src/tests/specifications/test_change_detection.test.ts
+++ b/typescript/packages/reality-capture/src/tests/specifications/test_change_detection.test.ts
@@ -19,6 +19,15 @@ describe("change_detection specifications", () => {
       expect(() => ChangeDetectionInputsSchema.parse(valid)).not.to.throw();
     });
 
+    it("should validate valid inputs with pointCloudChangeDetector", () => {
+      const valid = {
+        model3DA: "contextSceneId1",
+        model3DB: "contextSceneId2",
+        pointCloudChangeDetector: "detectorId",
+      };
+      expect(() => ChangeDetectionInputsSchema.parse(valid)).not.to.throw();
+    });
+
     it("should fail when missing reference", () => {
       const invalid = { model3DB: "contextSceneId2" };
       expect(() => ChangeDetectionInputsSchema.parse(invalid)).to.throw(z.ZodError);

--- a/typescript/packages/reality-capture/src/tests/specifications/test_training_cd3d.test.ts
+++ b/typescript/packages/reality-capture/src/tests/specifications/test_training_cd3d.test.ts
@@ -1,0 +1,215 @@
+import { expect } from "chai";
+import { z } from "zod";
+import {
+  Segmentation3DPairSchema,
+  TrainingCD3DInputsSchema,
+  TrainingCD3DOutputsSchema,
+  TrainingCD3DOptionsSchema,
+  TrainingCD3DOutputsCreate,
+  TrainingCD3DSpecificationsCreateSchema,
+  TrainingCD3DSpecificationsSchema,
+  PointCloudFeature,
+} from "../../specifications/training";
+
+describe("Segmentation3DPairSchema", () => {
+  it("should validate a correct pair", () => {
+    const data = { segmentation3DA: "csA-id", segmentation3DB: "csB-id" };
+    expect(() => Segmentation3DPairSchema.parse(data)).not.to.throw();
+  });
+
+  it("should fail if segmentation3DA is missing", () => {
+    const data = { segmentation3DB: "csB-id" };
+    expect(() => Segmentation3DPairSchema.parse(data)).to.throw(z.ZodError);
+  });
+
+  it("should fail if segmentation3DB is missing", () => {
+    const data = { segmentation3DA: "csA-id" };
+    expect(() => Segmentation3DPairSchema.parse(data)).to.throw(z.ZodError);
+  });
+});
+
+describe("TrainingCD3DInputsSchema", () => {
+  it("should validate a correct input", () => {
+    const data = {
+      segmentation3DPairs: [
+        { segmentation3DA: "csA-id", segmentation3DB: "csB-id" },
+      ],
+      detectorName: "my-cd-detector",
+    };
+    expect(() => TrainingCD3DInputsSchema.parse(data)).not.to.throw();
+  });
+
+  it("should validate a correct input with preset", () => {
+    const data = {
+      segmentation3DPairs: [
+        { segmentation3DA: "csA-id", segmentation3DB: "csB-id" },
+      ],
+      preset: "path/to/preset",
+      detectorName: "my-cd-detector",
+    };
+    expect(() => TrainingCD3DInputsSchema.parse(data)).not.to.throw();
+  });
+
+  it("should validate with multiple pairs", () => {
+    const data = {
+      segmentation3DPairs: [
+        { segmentation3DA: "csA1", segmentation3DB: "csB1" },
+        { segmentation3DA: "csA2", segmentation3DB: "csB2" },
+      ],
+      detectorName: "my-cd-detector",
+    };
+    expect(() => TrainingCD3DInputsSchema.parse(data)).not.to.throw();
+  });
+
+  it("should fail if segmentation3DPairs is missing", () => {
+    const data = { detectorName: "my-cd-detector" };
+    expect(() => TrainingCD3DInputsSchema.parse(data)).to.throw(z.ZodError);
+  });
+
+  it("should fail if detectorName is missing", () => {
+    const data = {
+      segmentation3DPairs: [
+        { segmentation3DA: "csA-id", segmentation3DB: "csB-id" },
+      ],
+    };
+    expect(() => TrainingCD3DInputsSchema.parse(data)).to.throw(z.ZodError);
+  });
+});
+
+describe("TrainingCD3DOutputsSchema", () => {
+  it("should validate a correct output", () => {
+    const data = { detector: "det-id" };
+    expect(() => TrainingCD3DOutputsSchema.parse(data)).not.to.throw();
+  });
+
+  it("should fail if detector is missing", () => {
+    const data = {};
+    expect(() => TrainingCD3DOutputsSchema.parse(data)).to.throw(z.ZodError);
+  });
+});
+
+describe("TrainingCD3DOptionsSchema", () => {
+  it("should validate correct options", () => {
+    const data = {
+      epochs: 10,
+      spacing: 0.5,
+      features: [PointCloudFeature.RGB, PointCloudFeature.NORMAL],
+      ignoreClass: 0,
+      versionNumber: "1.0",
+    };
+    expect(() => TrainingCD3DOptionsSchema.parse(data)).not.to.throw();
+  });
+
+  it("should accept partial data", () => {
+    const data = {};
+    expect(() => TrainingCD3DOptionsSchema.parse(data)).not.to.throw();
+  });
+
+  it("should fail if epochs is not an int", () => {
+    const data = { epochs: 3.5 };
+    expect(() => TrainingCD3DOptionsSchema.parse(data)).to.throw(z.ZodError);
+  });
+
+  it("should fail if epochs is < 1", () => {
+    const data = { epochs: 0 };
+    expect(() => TrainingCD3DOptionsSchema.parse(data)).to.throw(z.ZodError);
+  });
+
+  it("should fail if epochs is > 100", () => {
+    const data = { epochs: 101 };
+    expect(() => TrainingCD3DOptionsSchema.parse(data)).to.throw(z.ZodError);
+  });
+
+  it("should fail if spacing is <= 0", () => {
+    const data = { spacing: 0 };
+    expect(() => TrainingCD3DOptionsSchema.parse(data)).to.throw(z.ZodError);
+  });
+
+  it("should fail if versionNumber has invalid format", () => {
+    const data = { versionNumber: "abc" };
+    expect(() => TrainingCD3DOptionsSchema.parse(data)).to.throw(z.ZodError);
+  });
+
+  it("should accept valid versionNumber formats", () => {
+    expect(() => TrainingCD3DOptionsSchema.parse({ versionNumber: "1" })).not.to.throw();
+    expect(() => TrainingCD3DOptionsSchema.parse({ versionNumber: "2.3" })).not.to.throw();
+  });
+});
+
+describe("TrainingCD3DSpecificationsCreateSchema", () => {
+  it("should validate a minimal spec", () => {
+    const data = {
+      inputs: {
+        segmentation3DPairs: [
+          { segmentation3DA: "csA-id", segmentation3DB: "csB-id" },
+        ],
+        detectorName: "my-cd-detector",
+      },
+      outputs: [TrainingCD3DOutputsCreate.DETECTOR],
+    };
+    expect(() => TrainingCD3DSpecificationsCreateSchema.parse(data)).not.to.throw();
+  });
+
+  it("should validate a full spec", () => {
+    const data = {
+      inputs: {
+        segmentation3DPairs: [
+          { segmentation3DA: "csA-id", segmentation3DB: "csB-id" },
+        ],
+        preset: "path/to/preset",
+        detectorName: "my-cd-detector",
+      },
+      outputs: [TrainingCD3DOutputsCreate.DETECTOR],
+      options: {
+        epochs: 5,
+        spacing: 1.0,
+        features: [PointCloudFeature.INTENSITY],
+        ignoreClass: 2,
+        versionNumber: "3.1",
+      },
+    };
+    expect(() => TrainingCD3DSpecificationsCreateSchema.parse(data)).not.to.throw();
+  });
+
+  it("should fail if outputs contains invalid value", () => {
+    const data = {
+      inputs: {
+        segmentation3DPairs: [
+          { segmentation3DA: "csA-id", segmentation3DB: "csB-id" },
+        ],
+        detectorName: "my-cd-detector",
+      },
+      outputs: ["notValidValue"],
+    };
+    expect(() => TrainingCD3DSpecificationsCreateSchema.parse(data)).to.throw(z.ZodError);
+  });
+});
+
+describe("TrainingCD3DSpecificationsSchema", () => {
+  it("should validate a full specification", () => {
+    const data = {
+      inputs: {
+        segmentation3DPairs: [
+          { segmentation3DA: "csA-id", segmentation3DB: "csB-id" },
+        ],
+        detectorName: "my-cd-detector",
+      },
+      outputs: { detector: "det-id" },
+      options: { epochs: 2, spacing: 0.1 },
+    };
+    expect(() => TrainingCD3DSpecificationsSchema.parse(data)).not.to.throw();
+  });
+
+  it("should fail if outputs is invalid", () => {
+    const data = {
+      inputs: {
+        segmentation3DPairs: [
+          { segmentation3DA: "csA-id", segmentation3DB: "csB-id" },
+        ],
+        detectorName: "my-cd-detector",
+      },
+      outputs: {},
+    };
+    expect(() => TrainingCD3DSpecificationsSchema.parse(data)).to.throw(z.ZodError);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `TrainingCD3D` job type and `pointCloudChangeDetector` input to both Python and TypeScript SDKs.

### Python SDK
- Add `TrainingCD3D` specifications (`TrainingCD3DInputs`, `TrainingCD3DOutputs`, `TrainingCD3DOptions`) in `training.py`
- Add `pointCloudChangeDetector` optional input to `ChangeDetectionInputs`
- Register `TrainingCD3D` job type in the `Analysis` service
- Add validation tests

### TypeScript SDK
- Add `TrainingCD3D` specifications in `training.ts`
- Add `pointCloudChangeDetector` optional input to `ChangeDetectionInputs`
- Register `TrainingCD3D` job type in the `Analysis` service
- Add unit tests